### PR TITLE
fix: set specific version for openssl to fix crate publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Rust API Client"
 license = "MIT"
 
 [target.x86_64-unknown-linux-musl.dependencies]
-openssl = { version = "*", features = ["vendored"] }
+openssl = { version = "0.10.46", features = ["vendored"] }
 
 [lib]
 crate-type = ["lib"]


### PR DESCRIPTION
Caused by:
  the remote server responded with an error (status 400 Bad Request): wildcard (`*`) dependency constraints are not allowed on crates.io. Crate with this problem: `openssl` See https://doc.rust-lang.org/cargo/faq.html#can-libraries-use--as-a-version-for-their-dependencies for more information
Error: Process completed with exit code 101.
